### PR TITLE
TASK_Load_planned_tours_by_user_id

### DIFF
--- a/snowscape_tracker/lib/commands/planned_tour_command.dart
+++ b/snowscape_tracker/lib/commands/planned_tour_command.dart
@@ -11,6 +11,7 @@ import 'package:snowscape_tracker/data/planned_tour.dart';
 import 'package:snowscape_tracker/data/rules/matched_rule.dart';
 import 'package:snowscape_tracker/helpers/directions_handler.dart';
 import 'package:snowscape_tracker/helpers/match_rules.dart';
+import 'package:snowscape_tracker/utils/user_preferences.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
 
@@ -172,6 +173,7 @@ class PlannedTourCommand extends BaseCommand {
     }
 
     plannedTourModel.setTotalElevationGain = 0;
+    plannedTourModel.setContextPoints = [];
     plannedTourModel.setLoadingPathData = true;
     // int totalElevation =
     //     await arcGISService.getElevationGain(plannedTourModel.route);
@@ -230,6 +232,7 @@ class PlannedTourCommand extends BaseCommand {
     }
     PlannedTourDb plannedTourDb = PlannedTourDb(
       id: plannedTourId,
+      userId: UserPreferences.getUserUid() ?? "",
       tourName: plannedTourModel.plannedTourNameController.text.trim(),
       distance: plannedTour.distance,
       duration: plannedTour.duration,
@@ -283,8 +286,10 @@ class PlannedTourCommand extends BaseCommand {
       version: 1,
     );
 
-    final List<Map<String, dynamic>> maps =
-        await database.query('planned_tours');
+    final List<Map<String, dynamic>> maps = await database.query(
+        'planned_tours',
+        where: "userId = ?",
+        whereArgs: [UserPreferences.getUserUid()]);
 
     final List<Map<String, dynamic>> markers = await database.query('markers');
 

--- a/snowscape_tracker/lib/data/plannedTourDb/planned_tour_db.dart
+++ b/snowscape_tracker/lib/data/plannedTourDb/planned_tour_db.dart
@@ -1,5 +1,6 @@
 class PlannedTourDb {
   String? id;
+  String userId;
   String tourName;
   double distance;
   double totalElevationGain;
@@ -13,11 +14,13 @@ class PlannedTourDb {
     required this.totalElevationGain,
     required this.duration,
     required this.plannedTourTime,
+    required this.userId,
   });
 
   Map<String, dynamic> toMap() {
     return {
       'id': id,
+      'userId': userId,
       'tourName': tourName,
       'distance': distance,
       'totalElevationGain': totalElevationGain,
@@ -28,6 +31,7 @@ class PlannedTourDb {
 
   PlannedTourDb.fromMap(Map<String, dynamic> map)
       : id = map['id'],
+        userId = map['userId'],
         tourName = map['tourName'],
         distance = map['distance'],
         totalElevationGain = map['totalElevationGain'],
@@ -39,6 +43,7 @@ class PlannedTourDb {
     return '''
       CREATE TABLE planned_tours (
         id TEXT PRIMARY KEY,
+        userId TEXT,
         tourName TEXT,
         distance REAL,
         totalElevationGain REAL,

--- a/snowscape_tracker/lib/services/location_service.dart
+++ b/snowscape_tracker/lib/services/location_service.dart
@@ -63,10 +63,10 @@ class LocationService extends BaseCommand {
     if (permissionStatus.isDenied) {
       await Permission.location.request();
 
-      if (permissionStatus.isDenied) {
+      if (await Permission.location.status.isDenied) {
         await Permission.locationWhenInUse.request();
 
-        if (permissionStatus.isDenied) {
+        if (await Permission.locationWhenInUse.status.isDenied) {
           await SnackBarWidget.show(
               'Location permission is required to use this feature', null);
           await Future.delayed(Duration(seconds: 2));


### PR DESCRIPTION
Added user id (uid) to saved planned tour object so that we retrieve from the local database only those owned by the currently logged-in user. Also added a fix for multiplying context points on calculate and location permission status check.