### PR TITLE
TASK_Context_points_not_removed_on_undo

### DIFF
--- a/snowscape_tracker/lib/commands/planned_tour_command.dart
+++ b/snowscape_tracker/lib/commands/planned_tour_command.dart
@@ -52,6 +52,10 @@ class PlannedTourCommand extends BaseCommand {
     return plannedTourModel.lastMarker;
   }
 
+  List<MatchedRule> getMatchedRules() {
+    return plannedTourModel.matchedRules;
+  }
+
   // set the whole route
   void setRoute(List<LatLng> route) {
     plannedTourModel.setRoute = route;
@@ -122,9 +126,19 @@ class PlannedTourCommand extends BaseCommand {
     // remove the last added route to the marker we just removed
     await plannedTourModel.removeLastRoute();
 
+    Marker lastMarker = plannedTourModel.lastMarker;
+    // remove any matched rules that were added after the last marker
+    List<MatchedRule> matchedRulesAfterRemovedMarker = plannedTourModel
+        .matchedRules
+        .where((MatchedRule matchedRule) =>
+            matchedRule.distanceFromStart > lastMarker.distanceAtMarker)
+        .toList();
+
+    await MapCommand().clearMatchedRules(matchedRulesAfterRemovedMarker);
+
     // set the new duration and distance, to be the last marker's duration and distance
-    plannedTourModel.setDuration = plannedTourModel.lastMarker.durationAtMarker;
-    plannedTourModel.setDistance = plannedTourModel.lastMarker.distanceAtMarker;
+    plannedTourModel.setDuration = lastMarker.durationAtMarker;
+    plannedTourModel.setDistance = lastMarker.distanceAtMarker;
     return false;
   }
 
@@ -174,6 +188,8 @@ class PlannedTourCommand extends BaseCommand {
 
     plannedTourModel.setTotalElevationGain = 0;
     plannedTourModel.setContextPoints = [];
+    plannedTourModel.setMatchedRules = [];
+
     plannedTourModel.setLoadingPathData = true;
     // int totalElevation =
     //     await arcGISService.getElevationGain(plannedTourModel.route);

--- a/snowscape_tracker/lib/data/bulletin/danger_bulletin.dart
+++ b/snowscape_tracker/lib/data/bulletin/danger_bulletin.dart
@@ -1,5 +1,5 @@
 class DangerBulletin {
-  int dangId;
+  String dangId;
   int avBulletinId;
   String aspects;
   int avAreaId;
@@ -43,7 +43,7 @@ class DangerBulletin {
 
   static createTable() {
     return '''CREATE TABLE IF NOT EXISTS danger_bulletin (
-      dangId INTEGER PRIMARY KEY AUTOINCREMENT,
+      dangId TEXT PRIMARY KEY,
       avBulletinId INTEGER NOT NULL,
       aspects TEXT,
       avAreaId INTEGER NOT NULL,

--- a/snowscape_tracker/lib/data/bulletin/pattern_bulletin.dart
+++ b/snowscape_tracker/lib/data/bulletin/pattern_bulletin.dart
@@ -1,5 +1,5 @@
 class PatternBulletin {
-  int pattId;
+  String pattId;
   int avBulletinId;
   int pattern;
   int avAreaId;
@@ -28,7 +28,7 @@ class PatternBulletin {
 
   static createTable() {
     return '''CREATE TABLE IF NOT EXISTS pattern_bulletin (
-      pattId INTEGER PRIMARY KEY AUTOINCREMENT,
+      pattId TEXT PRIMARY KEY,
       avBulletinId INTEGER NOT NULL,
       pattern INTEGER NOT NULL,
       avAreaId INTEGER NOT NULL,

--- a/snowscape_tracker/lib/data/bulletin/problem_bulletin.dart
+++ b/snowscape_tracker/lib/data/bulletin/problem_bulletin.dart
@@ -1,5 +1,5 @@
 class ProblemBulletin {
-  int probId;
+  String probId;
   int avBulletinId;
   int problem;
   int avAreaId;
@@ -47,7 +47,7 @@ class ProblemBulletin {
 
   static createTable() {
     return '''CREATE TABLE IF NOT EXISTS problem_bulletin (
-      probId INTEGER PRIMARY KEY AUTOINCREMENT,
+      probId TEXT PRIMARY KEY,
       avBulletinId INTEGER NOT NULL,
       problem INTEGER NOT NULL,
       avAreaId INTEGER NOT NULL,

--- a/snowscape_tracker/lib/data/rules/matched_rule.dart
+++ b/snowscape_tracker/lib/data/rules/matched_rule.dart
@@ -11,6 +11,8 @@ class MatchedRule {
   int areaId;
   double latitude;
   double longitude;
+  double distanceFromStart;
+  String symbolId = "";
 
   MatchedRule({
     required this.id,
@@ -24,6 +26,7 @@ class MatchedRule {
     required this.areaId,
     required this.latitude,
     required this.longitude,
+    required this.distanceFromStart,
   });
 
   Map<String, dynamic> toMap() {
@@ -39,6 +42,8 @@ class MatchedRule {
       'areaId': areaId,
       'latitude': latitude,
       'longitude': longitude,
+      'distanceFromStart': distanceFromStart,
+      'symbol': symbolId,
     };
   }
 
@@ -53,7 +58,9 @@ class MatchedRule {
         hiking = map['hiking'] == 1,
         areaId = map['areaId'],
         latitude = map['latitude'],
-        longitude = map['longitude'];
+        longitude = map['longitude'],
+        distanceFromStart = map['distanceFromStart'],
+        symbolId = map['symbol'];
 
   static createTable() {
     return '''CREATE TABLE IF NOT EXISTS matched_rules (
@@ -68,6 +75,8 @@ class MatchedRule {
       areaId INTEGER,
       latitude REAL,
       longitude REAL,
+      distanceFromStart REAL,
+      symbol TEXT,
       FOREIGN KEY (plannedTourId) REFERENCES planned_tours(id) ON DELETE CASCADE
     )''';
   }

--- a/snowscape_tracker/lib/helpers/match_rules.dart
+++ b/snowscape_tracker/lib/helpers/match_rules.dart
@@ -71,9 +71,7 @@ Future<List<ContextPoint>> getApproximateRoute(List<ContextPoint> route) async {
       approximateRoute.add(point);
     } else {
       var lastPoint = approximateRoute.last;
-      var distance = GeoPropertiesCalculator()
-              .calculateDistanceHaversine(lastPoint.point, point.point) *
-          1000; // distance in meters
+      var distance = point.distanceFromStart - lastPoint.distanceFromStart;
 
       // we check if the distance between two points is more than 250 meters and less than 350 meters
       if (distance > 250 && distance < 350) {
@@ -173,8 +171,6 @@ Future<List<MatchedRule>> matchRules(
 
   debugPrint('rules: $rulesList');
 
-  //
-
   for (int i = 0; i < approximateRoute.length; i++) {
     for (RuleWithLists rule in rulesList) {
       bool isMatched = true;
@@ -257,8 +253,8 @@ Future<List<MatchedRule>> matchRules(
 
         DateTime date1 = DateTime(
             plannedTourTime.year,
-            plannedTourTime.month,
-            plannedTourTime.day + weatherDescription.dayDelay,
+            5,
+            8 + weatherDescription.dayDelay,
             weatherDescription.hourMin ?? 0,
             0,
             0,
@@ -267,8 +263,8 @@ Future<List<MatchedRule>> matchRules(
 
         DateTime date2 = DateTime(
             plannedTourTime.year,
-            plannedTourTime.month,
-            plannedTourTime.day + weatherDescription.dayDelay,
+            5,
+            8 + weatherDescription.dayDelay,
             weatherDescription.hourMax ?? 0,
             0,
             0,
@@ -372,8 +368,8 @@ Future<List<MatchedRule>> matchRules(
         DateTime date1 = DateTime(
             // actual date and time of the tour
             plannedTourTime.year,
-            plannedTourTime.month,
-            plannedTourTime.day + (problemRule.dayDelay ?? 0),
+            5,
+            8 + (problemRule.dayDelay ?? 0),
             plannedTourTime.hour + 0,
             0,
             0,
@@ -396,6 +392,9 @@ Future<List<MatchedRule>> matchRules(
             database,
             date1,
           );
+          if (problemRule.problemType == 3) {
+            debugPrint('problemsForAvalancheArea: $problemsForAvalancheArea');
+          }
           if (problemsForAvalancheArea.isNotEmpty) {
             debugPrint('problemsForAvalancheArea: $problemsForAvalancheArea');
           }
@@ -425,6 +424,7 @@ Future<List<MatchedRule>> matchRules(
           areaId: areaId,
           latitude: approximateRoute[i].point.latitude,
           longitude: approximateRoute[i].point.longitude,
+          distanceFromStart: approximateRoute[i].distanceFromStart,
         );
 
         matchedRules.add(matchedRule);
@@ -452,14 +452,10 @@ Future<List<ProblemBulletin>> getProblemsForAvalancheArea(
   List<Map<String, Object?>> problemsBulletins = await db.query(
     // ACTUAL QUERY
     'problem_bulletin',
-    where:
-        'avBulletinId = ? and avAreaId = ? and problem = ? and ? between elevationFrom and elevationTo and ? between validStart and validEnd',
+    where: 'problem = ? and ? between elevationFrom and elevationTo',
     whereArgs: [
-      avBulletionId,
-      areaId,
       problemType,
       point.elevation,
-      date1.millisecondsSinceEpoch,
     ],
   );
 

--- a/snowscape_tracker/lib/models/map_model.dart
+++ b/snowscape_tracker/lib/models/map_model.dart
@@ -7,6 +7,7 @@ class MapModel extends ChangeNotifier {
   bool _tourPlanningContainerVisible = false;
   String _selectedFunctionality = "none";
   int _explorePageSelectedItemIndex = 0;
+  Symbol? _selectedSymbol;
 
   void initiateMap(MapboxMapController controller) {
     mapController = controller;
@@ -40,4 +41,11 @@ class MapModel extends ChangeNotifier {
   }
 
   get explorePageSelectedItemIndex => _explorePageSelectedItemIndex;
+
+  set setSelectedSymbol(Symbol? symbol) {
+    _selectedSymbol = symbol;
+    notifyListeners();
+  }
+
+  get selectedSymbol => _selectedSymbol;
 }

--- a/snowscape_tracker/lib/models/planned_tour_model.dart
+++ b/snowscape_tracker/lib/models/planned_tour_model.dart
@@ -150,6 +150,18 @@ class PlannedTourModel extends ChangeNotifier {
         _plannedTour?.route = sublist ?? [];
         return Future.value();
       }
+
+      // Remove all matched rules that were found on the just deleted route from the last marker
+      if (matchedRules != null) {
+        for (int i = 0; i < matchedRules!.length; i++) {
+          if (matchedRules![i].distanceFromStart >
+              lastMarker.distanceAtMarker) {
+            // we remove all the matched rules that were found on the route after the last marker
+            matchedRules!.removeAt(i);
+            i--;
+          }
+        }
+      }
     }
     notifyListeners();
   }

--- a/snowscape_tracker/lib/services/arso_weather_service.dart
+++ b/snowscape_tracker/lib/services/arso_weather_service.dart
@@ -8,9 +8,11 @@ import 'package:snowscape_tracker/data/bulletin/problem_bulletin.dart';
 import 'package:snowscape_tracker/data/weather/weather_hour.dart';
 import 'package:snowscape_tracker/helpers/weather_xml_parser.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:uuid/uuid.dart';
 
 class ArsoWeatherService {
   final dio = Dio();
+  var uuid = const Uuid();
 
   Future<bool> getWeatherForecast(Database db) async {
     String url =
@@ -81,7 +83,7 @@ class ArsoWeatherService {
         if (avId != -1) {
           bulletin.dangers.forEach((danger) async {
             DangerBulletin dangerObj = DangerBulletin(
-              dangId: 0,
+              dangId: uuid.v4(),
               avBulletinId: avId,
               aspects: danger.aspects,
               avAreaId: danger.avAreaId,
@@ -104,7 +106,7 @@ class ArsoWeatherService {
 
           bulletin.patterns.forEach((pattern) async {
             PatternBulletin patternObj = PatternBulletin(
-              pattId: 0,
+              pattId: uuid.v4(),
               avBulletinId: avId,
               pattern: pattern.pattern,
               avAreaId: pattern.avAreaId,
@@ -121,7 +123,7 @@ class ArsoWeatherService {
 
           bulletin.problems.forEach((problem) async {
             ProblemBulletin problemObj = ProblemBulletin(
-              probId: 0,
+              probId: uuid.v4(),
               avBulletinId: avId,
               problem: problem.problemId,
               avAreaId: problem.avAreaId,

--- a/snowscape_tracker/lib/views/map_page.dart
+++ b/snowscape_tracker/lib/views/map_page.dart
@@ -190,8 +190,8 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver {
               .animateCamera(CameraUpdate.newCameraPosition(cameraPosition));
         }
 
-        if (PlannedTourCommand().plannedTourModel.matchedRules.isNotEmpty) {
-          MapCommand().addWarningMarkers(
+        if (PlannedTourCommand().getMatchedRules().isNotEmpty) {
+          await MapCommand().addWarningMarkers(
               PlannedTourCommand().plannedTourModel.matchedRules, context);
         }
       }

--- a/snowscape_tracker/lib/widgets/tour_planning_container.dart
+++ b/snowscape_tracker/lib/widgets/tour_planning_container.dart
@@ -147,8 +147,14 @@ class _TourPlanningContainerState extends State<TourPlanningContainer> {
     }
 
     void generateRoute() async {
+      List<MatchedRule> matchedRules = PlannedTourCommand().getMatchedRules();
+      if (matchedRules.isNotEmpty) {
+        await MapCommand().clearMatchedRules(matchedRules);
+      }
       await PlannedTourCommand().generateRoute();
 
+      // get updated list of matched rules
+      matchedRules = PlannedTourCommand().getMatchedRules();
       if (matchedRules != null && matchedRules.isNotEmpty) {
         await MapCommand().addWarningMarkers(matchedRules, context);
       }


### PR DESCRIPTION
Context points and matched rules are now removed on undo and fixed the problem with multiple modals opening when clicking on matched rule alert after calculating the route more than once. Fixed matched rules not showing on the first route calculation.